### PR TITLE
Fixed root setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,15 @@ from os import path
 
 from setuptools import setup, find_packages
 
-package_path = '.'
 
 if sys.platform == "darwin":  # mac
-    package_path = path.join(package_path, "mac", "x86-64")
-elif sys.platform != "win":  # linux
-    package_path = path.join(package_path, "linux", "x86-64")
+    package_path = path.join("mac", "x86-64")
+elif sys.platform == "linux":  # linux
+    package_path = path.join("linux", "x86-64")
 elif sys.maxsize > 2 ** 32:  # 64 bit windows
-    package_path = path.join(package_path, "windows", "win64")
+    package_path = path.join("windows", "win64")
 else:  # 32 bit windows
-    package_path = path.join(package_path, "windows", "win32")
+    package_path = path.join("windows", "win32")
 
 if sys.version[0] == '3':
     package_path = path.join(package_path, 'python3')


### PR DESCRIPTION
fix package_path in root setup.py  for  installing via pip install -e (developer install)  according to [https://docs.python.org/3.6/distutils/setupscript.html#listing-whole-packages](https://docs.python.org/3.6/distutils/setupscript.html#listing-whole-packages)

fix installation on win32 and win64