### PR TITLE
raspberry pi 2.7 fix for bad method signature

### DIFF
--- a/raspberrypi/python2.7/acrcloud/recognizer.py
+++ b/raspberrypi/python2.7/acrcloud/recognizer.py
@@ -171,12 +171,12 @@ class ACRCloudRecognizer:
             res = ACRCloudStatusCode.get_result_error(ACRCloudStatusCode.UNKNOW_ERROR_CODE, str(e))
         return res
 
-    def recognize_by_file(self, file_path, start_seconds=0, rec_length=10, filter_e=0):
+    def recognize_by_file(self, file_path, start_seconds=0, rec_length=10):
         res = ''
         try:
             query_data = {}
             if self.recognize_type == ACRCloudRecognizeType.ACR_OPT_REC_AUDIO or self.recognize_type == ACRCloudRecognizeType.ACR_OPT_REC_BOTH:
-                query_data['sample'] = acrcloud_extr_tool.create_fingerprint_by_file(file_path, start_seconds, rec_length, False, filter_e)
+                query_data['sample'] = acrcloud_extr_tool.create_fingerprint_by_file(file_path, start_seconds, rec_length, False)
 
             if self.recognize_type == ACRCloudRecognizeType.ACR_OPT_REC_HUMMING or self.recognize_type == ACRCloudRecognizeType.ACR_OPT_REC_BOTH:
                 query_data['sample_hum'] = acrcloud_extr_tool.create_humming_fingerprint_by_file(file_path, start_seconds, rec_length)


### PR DESCRIPTION
remove `filter_e` from call to `acrcloud_extr_tool.create_fingerprint_by_file` since it no longer seems to accept it

Fixes https://github.com/acrcloud/acrcloud_sdk_python/issues/7